### PR TITLE
Add PHP (composer) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Confused
 
-A tool for checking for lingering free namespaces for private package names referenced in dependency configuration 
-for Python (pypi) `requirements.txt` or JavaScript (npm) `package.json`
+A tool for checking for lingering free namespaces for private package names referenced in dependency configuration
+for Python (pypi) `requirements.txt`, JavaScript (npm) `package.json` or PHP (composer) `composer.json`.
 
 
-## Installation 
+## Installation
 
 - [Download](https://github.com/visma-prodsec/confused/releases/latest) a prebuilt binary from [releases page](https://github.com/visma-prodsec/confused/releases/latest), unpack and run!
 
@@ -21,7 +21,7 @@ Usage:
 
 Usage of ./confused:
   -l string
-        Package repository system. Possible values: "pip", "npm" (default "pip")
+        Package repository system. Possible values: "pip", "npm", "composer" (default "pip")
   -v    Verbose output
 
 ```

--- a/composer.go
+++ b/composer.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+type ComposerJSON struct {
+	Require map[string]string `json:"require"`
+	RequireDev map[string]string `json:"require-dev"`
+}
+
+type ComposerLookup struct {
+	Packages []string
+	Verbose bool
+}
+
+func NewComposerLookup(verbose bool) PackageResolver {
+	return &ComposerLookup{Packages: []string{}, Verbose: verbose}
+}
+
+func (c *ComposerLookup) ReadPackagesFromFile(filename string) error {
+	rawfile, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	data := ComposerJSON{}
+	err = json.Unmarshal([]byte(rawfile), &data)
+	if err != nil {
+		return err
+	}
+
+	for pkgname, _ := range data.Require {
+		c.Packages = append(c.Packages, pkgname)
+	}
+
+	for pkgname, _ := range data.RequireDev {
+		c.Packages = append(c.Packages, pkgname)
+	}
+
+	return nil
+}
+
+func (c *ComposerLookup) PackagesNotInPublic() []string {
+	notavail := []string{}
+	for _, pkg := range c.Packages {
+		if pkg == "php" {
+			continue
+		}
+
+		if !c.isAvailableInPublic(pkg, 0) {
+			notavail = append(notavail, pkg)
+		}
+	}
+
+	return notavail
+}
+
+func (c *ComposerLookup) isAvailableInPublic(pkgname string, retry int) bool {
+	if retry > 3 {
+		fmt.Printf(" [W] Maximum number of retries exhausted for package %s\n", pkgname)
+
+		return false
+	}
+
+	if c.Verbose {
+		fmt.Printf("Checking: https://packagist.org/packages/%s : ", pkgname)
+	}
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Get("https://packagist.org/packages/" + pkgname)
+	defer resp.Body.Close()
+	if err != nil {
+		fmt.Printf(" [W] Error when trying to request https://packagist.org/packages/%s : %s\n", pkgname, err)
+
+		return false
+	}
+
+	if c.Verbose {
+		fmt.Printf("%s\n", resp.Status)
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		return true
+	}
+
+	if resp.StatusCode == 429 {
+		fmt.Printf(" [!] Server responded with 429 (Too many requests), throttling and retrying..\n")
+		time.Sleep(10 * time.Second)
+		retry = retry + 1
+
+		c.isAvailableInPublic(pkgname, retry)
+	}
+
+	return false
+}

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ func main() {
 	lang := ""
 	verbose := false
 	filename := ""
-	flag.StringVar(&lang, "l", "npm", "Package repository system. Possible values: \"pip\", \"npm\"")
+	flag.StringVar(&lang, "l", "npm", "Package repository system. Possible values: \"pip\", \"npm\", \"composer\"")
 	flag.BoolVar(&verbose, "v", false, "Verbose output")
 	flag.Parse()
 
@@ -27,6 +27,8 @@ func main() {
 		resolver = NewPythonLookup(verbose)
 	} else if lang == "npm" {
 		resolver = NewNPMLookup(verbose)
+	} else if lang == "composer" {
+		resolver = NewComposerLookup(verbose)
 	} else {
 		fmt.Printf("Unknown package repository system: %s\n", lang)
 		os.Exit(1)


### PR DESCRIPTION
This PR adds support for [PHP](https://www.php.net/) checking based on [Composer](https://getcomposer.org/) dependency manager.

The dependencies are checked against Composer's official package repository [Packagist](https://packagist.org/).

Please note that the way composer handles dependencies is quite different from pip and npm, the developer can define[1]:
1. Different source repositories for a package
2. Different package repository without disabling Packagist
3. Different package repository disabling Packagist

The current implementation does not check for those configuration changes.

There is also a very thorough blog post[2] that explains why PHP/Composer is not susceptive to this attack. 

[1] https://getcomposer.org/doc/05-repositories.md
[2] https://blog.packagist.com/preventing-dependency-hijacking/