### PR TITLE
Fixes #1 npm unmarshalling

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -1,5 +1,10 @@
 package main
 
+// A PackageResolver resolves package information from a file
+//
+// ReadPackagesFromFile should take a filepath as input and parse relevant package information into a struct and then return any errors encountered while reading or unmarshalling the file.
+//
+// PackagesNotInPublic should determine whether or not a package is not available in a public package repository and return a slice of all packages not available in a public package repository.
 type PackageResolver interface {
 	ReadPackagesFromFile(string) error
 	PackagesNotInPublic() []string

--- a/main.go
+++ b/main.go
@@ -1,3 +1,10 @@
+/*
+Package main implements an automated Dependency Confusion scanner.
+
+Original research provided by Alex Birsan.
+
+Original blog post detailing Dependency Confusion : https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610 .
+*/
 package main
 
 import (
@@ -39,12 +46,14 @@ func main() {
 	PrintResult(resolver.PackagesNotInPublic())
 }
 
+// Help outputs tool usage and help
 func Help() {
 	fmt.Println(fmt.Sprintf(`Usage:
  %s [-l LANGUAGENAME] depfilename.ext
 `, os.Args[0]))
 }
 
+// PrintResult outputs the result of the scanner
 func PrintResult(notavail []string) {
 	if len(notavail) == 0 {
 		fmt.Printf(" [*] All packages seem to be available in the public repositories. Dependency confusion should not be possible.\n")

--- a/npm.go
+++ b/npm.go
@@ -8,6 +8,7 @@ import (
 	"time"
 )
 
+// PackageJSON represents the dependencies of an npm package
 type PackageJSON struct {
 	Dependencies         map[string]string `json:"dependencies,omitempty"`
 	DevDependencies      map[string]string `json:"devDependencies,omitempty"`
@@ -17,15 +18,20 @@ type PackageJSON struct {
 	OptionalDependencies map[string]string `json:"optionalDependencies,omitempty"`
 }
 
+// NPMLookup represents a collection of npm packages to be tested for dependency confusion.
 type NPMLookup struct {
 	Packages []string
 	Verbose  bool
 }
 
+// NewNPMLookup constructs an `NPMLookup` struct and returns it.
 func NewNPMLookup(verbose bool) PackageResolver {
 	return &NPMLookup{Packages: []string{}, Verbose: verbose}
 }
 
+// ReadPackagesFromFile reads package information from an npm package.json file
+//
+// Returns any errors encountered
 func (n *NPMLookup) ReadPackagesFromFile(filename string) error {
 	rawfile, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -57,6 +63,9 @@ func (n *NPMLookup) ReadPackagesFromFile(filename string) error {
 	return nil
 }
 
+// PackagesNotInPublic determines if an npm package does not exist in the public npm package repository.
+//
+// Returns a slice of strings with any npm packages not in the public npm package repository
 func (n *NPMLookup) PackagesNotInPublic() []string {
 	notavail := []string{}
 	for _, pkg := range n.Packages {
@@ -67,6 +76,9 @@ func (n *NPMLookup) PackagesNotInPublic() []string {
 	return notavail
 }
 
+// isAvailableInPublic determines if an npm package exists in the public npm package repository.
+//
+// Returns true if the package exists in the public npm package repository.
 func (n *NPMLookup) isAvailableInPublic(pkgname string, retry int) bool {
 	if retry > 3 {
 		fmt.Printf(" [W] Maximum number of retries exhausted for package: %s\n", pkgname)

--- a/npm.go
+++ b/npm.go
@@ -42,16 +42,16 @@ func (n *NPMLookup) ReadPackagesFromFile(filename string) error {
 	if err != nil {
 		return err
 	}
-	for pkgname, _ := range data.Dependencies {
+	for pkgname := range data.Dependencies {
 		n.Packages = append(n.Packages, pkgname)
 	}
-	for pkgname, _ := range data.DevDependencies {
+	for pkgname := range data.DevDependencies {
 		n.Packages = append(n.Packages, pkgname)
 	}
-	for pkgname, _ := range data.PeerDependencies {
+	for pkgname := range data.PeerDependencies {
 		n.Packages = append(n.Packages, pkgname)
 	}
-	for pkgname, _ := range data.OptionalDependencies {
+	for pkgname := range data.OptionalDependencies {
 		n.Packages = append(n.Packages, pkgname)
 	}
 	for _, pkgname := range data.BundledDependencies {

--- a/npm.go
+++ b/npm.go
@@ -9,17 +9,17 @@ import (
 )
 
 type PackageJSON struct {
-	Dependencies map[string]string `json:"dependencies"`
-	DevDependencies map[string]string `json:"devDependencies"`
-	PeerDependencies map[string]string `json:"peerDependencies"`
-	BundledDependencies []string `json:"bundledDependencies"`
-	BundleDependencies []string `json:"bundleDependencies"`
-	OptionalDependencies map[string]string `json:"optionalDependencies"`
+	Dependencies         map[string]string `json:"dependencies,omitempty"`
+	DevDependencies      map[string]string `json:"devDependencies,omitempty"`
+	PeerDependencies     map[string]string `json:"peerDependencies,omitempty"`
+	BundledDependencies  []string          `json:"bundledDependencies,omitempty"`
+	BundleDependencies   []string          `json:"bundleDependencies,omitempty"`
+	OptionalDependencies map[string]string `json:"optionalDependencies,omitempty"`
 }
 
-type NPMLookup struct{
+type NPMLookup struct {
 	Packages []string
-	Verbose bool
+	Verbose  bool
 }
 
 func NewNPMLookup(verbose bool) PackageResolver {
@@ -77,7 +77,7 @@ func (n *NPMLookup) isAvailableInPublic(pkgname string, retry int) bool {
 	}
 	resp, err := http.Get("https://registry.npmjs.org/" + pkgname + "/")
 	if err != nil {
-		fmt.Printf(" [W] Error when trying to request https://registry.npmjs.org/" + pkgname + "/ : %s\n", err)
+		fmt.Printf(" [W] Error when trying to request https://registry.npmjs.org/"+pkgname+"/ : %s\n", err)
 		return false
 	}
 	if n.Verbose {

--- a/pip.go
+++ b/pip.go
@@ -7,15 +7,20 @@ import (
 	"strings"
 )
 
-type PythonLookup struct{
+// PythonLookup represents a collection of python packages to be tested for dependency confusion.
+type PythonLookup struct {
 	Packages []string
-	Verbose bool
+	Verbose  bool
 }
 
+// NewPythonLookup constructs a `PythonLookup` struct and returns it
 func NewPythonLookup(verbose bool) PackageResolver {
 	return &PythonLookup{Packages: []string{}, Verbose: verbose}
 }
 
+// ReadPackagesFromFile reads package information from a python `requirements.txt` file
+//
+// Returns any errors encountered
 func (p *PythonLookup) ReadPackagesFromFile(filename string) error {
 	rawfile, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -36,6 +41,9 @@ func (p *PythonLookup) ReadPackagesFromFile(filename string) error {
 	return nil
 }
 
+// PackagesNotInPublic determines if a python package does not exist in the pypi package repository.
+//
+// Returns a slice of strings with any python packages not in the pypi package repository
 func (p *PythonLookup) PackagesNotInPublic() []string {
 	notavail := []string{}
 	for _, pkg := range p.Packages {
@@ -58,13 +66,16 @@ func (p *PythonLookup) pipSplit(r rune) bool {
 	return inSlice(r, delims)
 }
 
+// isAvailableInPublic determines if a python package exists in the pypi package repository.
+//
+// Returns true if the package exists in the pypi package repository.
 func (p *PythonLookup) isAvailableInPublic(pkgname string) bool {
 	if p.Verbose {
 		fmt.Print("Checking: https://pypi.org/project/" + pkgname + "/ : ")
 	}
 	resp, err := http.Get("https://pypi.org/project/" + pkgname + "/")
 	if err != nil {
-		fmt.Printf(" [W] Error when trying to request https://pypi.org/project/" + pkgname + "/ : %s\n", err)
+		fmt.Printf(" [W] Error when trying to request https://pypi.org/project/"+pkgname+"/ : %s\n", err)
 		return false
 	}
 	if p.Verbose {


### PR DESCRIPTION
Fixes #1 by adding `omitempty` tags to the `PackageJSON` struct as not all `package.json` files contain every field in this struct.

Also satisfies `golint` by adding `godoc` comments to exported types, methods, and interfaces, as well as adding package level documentation.

Finally, simplifies the `range` statements in `npm.go` by removing the unnessary `_` empty variable