### PR TITLE
Add a command line parameter to flag namespaces as known-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 - main
     - New
         - PHP (composer) support
+        - Command line parameter to let the user to flag namespaces as known-safe
     - Changed
         - Python (pypi) dependency definition files that use line continuation are now parsed correctly
+        - Revised the output to clarify the usage
+        - Fixed npm package.json file parsing issues when the source file is not following the specification
 
 - v0.2
     - Changed

--- a/README.md
+++ b/README.md
@@ -47,13 +47,34 @@ Usage:
 Usage of ./confused:
   -l string
         Package repository system. Possible values: "pip", "npm", "composer" (default "npm")
+  -s string
+        Comma-separated list of known-secure namespaces. Supports wildcards
   -v    Verbose output
 
 ```
 
 ## Example
+
+### Python (PyPI)
 ```
 ./confused -l pip requirements.txt
+
+Issues found, the following packages are not available in public package repositories:
+ [!] internal_package1
+
+```
+
+### JavaScript (npm)
+```
+./confused -l npm package.json
+
+Issues found, the following packages are not available in public package repositories:
+ [!] internal_package1
+ [!] @mycompany/internal_package1
+ [!] @mycompany/internal_package2
+
+# Example when @mycompany private scope has been registered in npm, using -s
+./confused -l npm -s '@mycompany/*' package.json
 
 Issues found, the following packages are not available in public package repositories:
  [!] internal_package1

--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func PrintResult(notavail []string) {
 	for _, n := range notavail {
 		fmt.Printf(" [!] %s\n", n)
 	}
+	os.Exit(1)
 }
 
 // removeSafe removes known-safe package names from the slice
@@ -99,4 +100,3 @@ func removeSafe(packages []string, safespaces string) []string {
 	}
 	return retSlice
 }
-

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func PrintResult(notavail []string) {
 func removeSafe(packages []string, safespaces string) []string {
 	retSlice := []string{}
 	safeNamespaces := []string{}
-	var ignored bool = false
+	var ignored bool
 	safeTmp := strings.Split(safespaces, ",")
 	for _, s := range safeTmp {
 		safeNamespaces = append(safeNamespaces, strings.TrimSpace(s))


### PR DESCRIPTION
This is needed for CI/CD pipeline automation, as `confused` is not able to determine if packages in private scopes exist or not.