### PR TITLE
Update README.md fix install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ trusted party has claimed the scope name in the public repositories.
 - [Download](https://github.com/visma-prodsec/confused/releases/latest) a prebuilt binary from [releases page](https://github.com/visma-prodsec/confused/releases/latest), unpack and run!
 
   _or_
-- If you have recent go compiler installed: `go get -u github.com/visma-prodsec/confused` (the same command works for updating)
+- If you have recent go compiler installed: `go install github.com/visma-prodsec/confused@latest` (the same command works for updating)
 
   _or_
 - git clone https://github.com/visma-prodsec/confused ; cd confused ; go get ; go build


### PR DESCRIPTION
Update install method as go get -u is outdated and not working anymore.

`go get -u  repuURL` will no longer work. See error message below.

`go install repoURL@version` works..


Old error:
```
% go get -u github.com/visma-prodsec/confused
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```