### PR TITLE
cache npmjs package lookups in a local file

### DIFF
--- a/npm.go
+++ b/npm.go
@@ -101,6 +101,7 @@ func (n *NPMLookup) ReadPackagesFromFile(filename string) error {
 // Returns a slice of strings with any npm packages not in the public npm package repository
 func (n *NPMLookup) PackagesNotInPublic() []string {
 	notavail := []string{}
+	avail := readMap("/tmp/confused-npm-avail")
 	for _, pkg := range n.Packages {
 		if n.localReference(pkg.Version) || n.urlReference(pkg.Version) || n.gitReference(pkg.Version) {
 			continue
@@ -113,10 +114,13 @@ func (n *NPMLookup) PackagesNotInPublic() []string {
 				continue
 			}
 		}
-		if !n.isAvailableInPublic(pkg.Name, 0) {
+		if !avail[pkg.Name] && !n.isAvailableInPublic(pkg.Name, 0) {
 			notavail = append(notavail, pkg.Name)
+		} else {
+			avail[pkg.Name] = true
 		}
 	}
+	writeMap(avail, "/tmp/confused-npm-avail")
 	return notavail
 }
 

--- a/util.go
+++ b/util.go
@@ -1,6 +1,11 @@
 package main
 
-import "strings"
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
 
 func inSlice(what rune, where []rune) bool {
 	for _, r := range where {
@@ -13,4 +18,32 @@ func inSlice(what rune, where []rune) bool {
 
 func countLeadingSpaces(line string) int {
 	return len(line) - len(strings.TrimLeft(line, " "))
+}
+
+// reads line-delimited contents of a file into a map of strings
+func readMap(path string) map[string]bool {
+	file, err := os.Open(path)
+	if err != nil {
+		return map[string]bool{}
+	}
+	defer file.Close()
+
+	avail := map[string]bool{}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		avail[scanner.Text()] = true
+	}
+	return avail
+}
+
+// writes a map of strings to a line-delimited file
+func writeMap(lines map[string]bool, path string) {
+	file, _ := os.Create(path)
+	defer file.Close()
+
+	writer := bufio.NewWriter(file)
+	for key, _ := range lines {
+		fmt.Fprintln(writer, key)
+	}
+	writer.Flush()
 }


### PR DESCRIPTION
I'm scanning a large number of repositories that have npmjs package files. By caching the available packages, it runs substantially faster, avoids npmjs rate-limiting, and reduces load on their service.

Please let me know if you'd prefer anything changed in the PR. I'm inexperienced with golang.

If this general approach looks good to you, I'd be happy to expand it to the other package systems.